### PR TITLE
Fix overflows in randomInt

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "purescript-eff": "^0.1.0",
-    "purescript-integers": "^0.2.0",
+    "purescript-integers": "^0.2.1",
     "purescript-math": "^0.2.0"
   }
 }

--- a/src/Control/Monad/Eff/Random.purs
+++ b/src/Control/Monad/Eff/Random.purs
@@ -3,9 +3,7 @@ module Control.Monad.Eff.Random where
 import Prelude
 
 import Control.Monad.Eff (Eff())
-import Data.Int (fromNumber, toNumber)
-
-import qualified Data.Maybe.Unsafe as U
+import Data.Int (fromNumber, toNumber, floor)
 
 -- | The `RANDOM` effect indicates that an Eff action may access or modify the
 -- | JavaScript global random number generator, i.e. `Math.random()`.
@@ -28,7 +26,8 @@ foreign import random :: forall e. Eff (random :: RANDOM | e) Number
 randomInt :: forall e. Int -> Int -> Eff (random :: RANDOM | e) Int
 randomInt low high = do
   n <- random
-  pure <<< U.fromJust <<< fromNumber <<< Math.floor $ toNumber (high - low + one) * n + toNumber low
+  let asNumber = (toNumber high - toNumber low + one) * n + toNumber low
+  return $ floor asNumber
 
 -- | Returns a random number between a minimum value (inclusive) and a maximum
 -- | value (exclusive). It is unspecified what happens if `maximum < minimum`.


### PR DESCRIPTION
Fixes #9 

Fix overflows by turning everything into a `Number` first, and then converting it back at the end.

I decided not to bother with the export list yet because I thought you might want `safeFromNumber` to go into `purescript-integers` instead, perhaps with a different name. (`truncate`?) What do you think?