### PR TITLE
Remove unused import

### DIFF
--- a/src/Control/Monad/Eff/Random.purs
+++ b/src/Control/Monad/Eff/Random.purs
@@ -3,7 +3,7 @@ module Control.Monad.Eff.Random where
 import Prelude
 
 import Control.Monad.Eff (Eff())
-import Data.Int (fromNumber, toNumber, floor)
+import Data.Int (toNumber, floor)
 
 -- | The `RANDOM` effect indicates that an Eff action may access or modify the
 -- | JavaScript global random number generator, i.e. `Math.random()`.


### PR DESCRIPTION
The PureScript compiler warns about unused imports as of 0.7.6.