### PR TITLE
suppress psc 0.8.4 warning

### DIFF
--- a/src/Control/Monad/Eff/Random.purs
+++ b/src/Control/Monad/Eff/Random.purs
@@ -46,4 +46,4 @@ randomRange min max = do
 -- | Returns a random boolean value with an equal chance of being `true` or
 -- | `false`.
 randomBool :: forall e. Eff (random :: RANDOM | e) Boolean
-randomBool = (< 0.5) <$> random
+randomBool = (_ < 0.5) <$> random


### PR DESCRIPTION
```
in module Control.Monad.Eff.Random
at .../purescript-random/src/Control/Monad/Eff/Random.purs line 49, column 1 - line 49, column 26

  An operator section uses legacy syntax. Operator sections are now written using anonymous function syntax:

    (_ < 0.5)

  Support for legacy operator sections will be removed in PureScript 0.9.

in value declaration randomBool
```